### PR TITLE
UIScreen.getMainScreen().bounds fix on iPhone 8 simulator

### DIFF
--- a/ios/robovm.xml
+++ b/ios/robovm.xml
@@ -13,6 +13,13 @@
       </includes>
       <skipPngCrush>true</skipPngCrush>
     </resource>
+    <resource>
+      <directory>./data</directory>
+      <includes>
+        <include>**</include>
+      </includes>
+      <skipPngCrush>true</skipPngCrush>
+    </resource>
   </resources>
   <forceLinkClasses>
     <pattern>com.badlogic.gdx.scenes.scene2d.ui.*</pattern>


### PR DESCRIPTION
- `ios/data` added to resources in robovm.xml to resolve `UIScreen.getMainScreen().bounds` returning `320X480` on iPhone 8 simulator

Before:
<img width="449" alt="Screenshot 2022-03-22 at 4 11 13 PM" src="https://user-images.githubusercontent.com/8373036/159464013-19b358d7-09e2-4fbe-94d4-17410fc25dda.png">


After:
<img width="442" alt="Screenshot 2022-03-22 at 4 12 13 PM" src="https://user-images.githubusercontent.com/8373036/159464167-313fb36d-7254-416c-873b-9df16b774d79.png">

